### PR TITLE
updates phone validation

### DIFF
--- a/src/EzValidation.ts
+++ b/src/EzValidation.ts
@@ -98,7 +98,7 @@ class Validation {
   isPhoneNumber(errorMessage: string = "Must be valid Phone Number") {
     if (
       this.validating.match(
-        /^[\+]?[(]?[0-9]{3}[)]?[-\s\.]?[0-9]{3}[-\s\.]?[0-9]{4,6}$/im
+        /^(1\s?)?((\([0-9]{3}\))|[0-9]{3})[\s\-]?[\0-9]{3}[\s\-]?[0-9]{4}$/gm
       ) === null
     ) {
       this._returnError(errorMessage);

--- a/tests/ezValidation.test.tsx
+++ b/tests/ezValidation.test.tsx
@@ -144,6 +144,8 @@ describe("util/ezValidationTest", () => {
     expect(validation).toEqual(true);
     const validation2 = EzValidation("7702-3-42342").isPhoneNumber().hasError;
     expect(validation2).toEqual(true);
+    const validation3 = EzValidation("234567890123").isPhoneNumber().hasError;
+    expect(validation3).toEqual(true);
   });
 
   it("returns positive type isUSAZipCode checks", () => {


### PR DESCRIPTION
This blocks users from entering 12 digits (they were allowed to before because it counted dashes as applicable chars so you could put 12)